### PR TITLE
Update index.js to import Amplify with different format to avoid erro…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-import Amplify from "aws-amplify";
+import { Amplify } from "aws-amplify"
 import awsExports from "./aws-exports";
 
 


### PR DESCRIPTION
…rs during the build

It should solve the issue raised when doing amplify publish:

Creating an optimized production build...
Failed to compile.

Attempted import error: 'aws-amplify' does not contain a default export (imported as 'Amplify').


🛑 Build command "npm run-script build" exited with failure

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
